### PR TITLE
fix(ci): point lint script and docker tag condition at main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,7 +132,7 @@ jobs:
 
       # Tags applied:
       #   sha-<short-sha>  — every push
-      #   latest           — push to master/main only
+      #   latest           — push to main only
       #   v1.2.3 / 1.2     — on semver git tags
       - name: Extract Docker metadata
         id: meta
@@ -141,7 +141,7 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
           labels: |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:all": "backstage-cli repo test --coverage",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
-    "lint": "backstage-cli repo lint --since origin/master",
+    "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "new": "backstage-cli new"


### PR DESCRIPTION
## Summary
- `package.json` `lint` script: `--since origin/master` → `origin/main` (stale after the master→main rename).
- `.github/workflows/ci.yaml` metadata-action `latest` tag `enable` condition: drop the deleted `refs/heads/master` branch.

## CI note
The `Build & Audit` job fails on a **pre-existing unrelated** set of HIGH advisories against `tar@6.2.1` transitive via `node-gyp@10.3.1`. Tracked in #16. Not introduced by this PR. Scoped fix → merging with the failing audit; the `Scan & Push` step is already skipped on PRs.

## Test plan
- [x] `git diff` limited to the two refs flagged by #5.
- [x] Local render unchanged otherwise.
- [ ] After merge, resolve #16 so CI main-branch run goes green.

Closes #5