### PR TITLE
fix(ci): pin trivy-action to 0.35.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
 
       # Scan the image — exit-code 1 blocks the push if HIGH/CRITICAL CVEs found.
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: backstage-app:${{ github.sha }}
           format: sarif


### PR DESCRIPTION
## Summary
- \`aquasecurity/trivy-action@0.31.0\` is not a published tag. Runs fail with \`Unable to resolve action\`.
- Bump to \`0.35.0\` (current latest).