### PR TITLE
fix(ci): limit trivy sarif to filtered severities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,9 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true   # skip CVEs with no fix available
           trivyignores: .trivyignore
+          # Without this, sarif output includes every severity and exit-code
+          # triggers on any finding — we only want HIGH/CRITICAL to fail CI.
+          limit-severities-for-sarif: true
 
       # Always upload results so they appear in the Security → Code Scanning tab.
       - name: Upload Trivy SARIF to GitHub Security


### PR DESCRIPTION
## Summary
\`trivy-action\`'s sarif format bypasses the \`severity\` filter and the exit-code check triggers on any finding. CI failed on MEDIUM advisories despite \`severity: HIGH,CRITICAL\`.

\`limit-severities-for-sarif: true\` applies the filter to both SARIF output and the exit-code gate.