### PR TITLE
docs(readme): add CI and Trivy scan status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # [Backstage](https://backstage.io)
 
+[![CI](https://github.com/renatts/backstage-app/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/renatts/backstage-app/actions/workflows/ci.yaml)
+[![Trivy](https://img.shields.io/github/actions/workflow/status/renatts/backstage-app/ci.yaml?branch=main&job=Scan%20%26%20Push&label=trivy%20scan)](https://github.com/renatts/backstage-app/actions/workflows/ci.yaml)
+
 This is your newly scaffolded Backstage App, Good Luck!
 
 To start the app, run:


### PR DESCRIPTION
## Summary
- CI workflow badge
- Trivy scan badge (scoped to the \`Scan & Push\` job)

Closes #22