### PR TITLE
ci: bump Node.js to 24 to match runtime image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "22"
+  NODE_VERSION: "24"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Job 1 — Build & Audit


### PR DESCRIPTION
## Summary
Dockerfile runs \`node:24-trixie-slim\` but CI was validating on Node 22. Align CI to 24 so tests exercise the version the image ships.

Root \`engines\` field already allows \`"22 || 24"\`.

Closes #8